### PR TITLE
Allow overriding prefix for ranlib separately

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,9 +18,14 @@ else
   CXXFLAGS := $(CXXFLAGS) -fPIC
 endif
 
+# Allow overriding prefix for ranlib separately
+ifndef PREFIX_RANLIB_USE
+  PREFIX_RANLIB := $(PREFIX)
+endif
+
 ##################
 ARFLAGS = -cr	# ar needs the dash on OpenBSD
-RANLIB = $(PREFIX)ranlib
+RANLIB = $(PREFIX_RANLIB)ranlib
 CP = cp
 MKDIR = mkdir
 EGREP = egrep


### PR DESCRIPTION
Groundwork for further changes to PSCrypto (https://github.com/psforever/PSCrypto).

Technical details:
Defining PREFIX_RANLIB_USE causes the makefile to prefix the 'ranlib' command name with PREFIX_RANLIB.
Otherwise the command will be prefixed with PREFIX, as is the current behaviour.
This feature was motivated by attempting to compile the project on a Linux Fedora distro.
(Which requires a prefix for the ranlib command, different than the prefix for GCC et al)
